### PR TITLE
feat:[TR-812] Note-length-settings

### DIFF
--- a/app/admin/north_utility.rb
+++ b/app/admin/north_utility.rb
@@ -8,6 +8,7 @@ ActiveAdmin.register NorthUtility do
     name code base_url external_api_key external_api_secret
     external_api_authentication_url books_data_url
     external_api_authentication_url notes_data_url
+    max_word_short_content max_word_medium_content
   ]
 
   member_action :copy, method: :get do
@@ -50,6 +51,8 @@ ActiveAdmin.register NorthUtility do
       f.input :external_api_authentication_url, as: :url
       f.input :books_data_url, as: :url
       f.input :notes_data_url, as: :url
+      f.input :max_word_short_content
+      f.input :max_word_medium_content
       f.actions
     end
   end

--- a/app/admin/south_utility.rb
+++ b/app/admin/south_utility.rb
@@ -8,6 +8,7 @@ ActiveAdmin.register SouthUtility do
     name code base_url external_api_key external_api_secret
     external_api_authentication_url books_data_url
     external_api_authentication_url notes_data_url
+    max_word_short_content max_word_medium_content
   ]
 
   member_action :copy, method: :get do
@@ -49,6 +50,8 @@ ActiveAdmin.register SouthUtility do
       f.input :external_api_authentication_url, as: :url
       f.input :books_data_url, as: :url
       f.input :notes_data_url, as: :url
+      f.input :max_word_short_content
+      f.input :max_word_medium_content
       f.actions
     end
   end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,7 +4,7 @@ module Api
       before_action :authenticate_user!
 
       def current
-        render json: current_user, status: :ok, serializer: UserSerializer 
+        render json: current_user, status: :ok, serializer: UserSerializer
       end
     end
   end

--- a/app/models/north_utility.rb
+++ b/app/models/north_utility.rb
@@ -2,12 +2,4 @@ class NorthUtility < Utility
   def max_word_valid_review
     50
   end
-
-  def max_word_short_content
-    50
-  end
-
-  def max_word_medium_content
-    100
-  end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -22,11 +22,19 @@ class Note < ApplicationRecord
     content.split(/\s+/).size
   end
 
+  def short_limit
+    [utility.max_word_short_content.to_i, 1].max
+  end
+
+  def medium_limit
+    [utility.max_word_medium_content.to_i, short_limit + 2].max
+  end
+
   def content_length
     case word_count
-    when 0..max_word_short
+    when 0..short_limit
       'short'
-    when (max_word_short + 1)..max_word_medium
+    when (short_limit + 1)..medium_limit
       'medium'
     else
       'long'
@@ -34,14 +42,6 @@ class Note < ApplicationRecord
   end
 
   private
-
-  def max_word_short
-    (utility.max_word_short_content || 0)
-  end
-
-  def max_word_medium
-    (utility.max_word_medium_content || 2)
-  end
 
   def validate_review_word_count
     return unless word_count > utility.max_word_valid_review

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -24,9 +24,9 @@ class Note < ApplicationRecord
 
   def content_length
     case word_count
-    when 0..utility.max_word_short_content
+    when 0..max_word_short
       'short'
-    when (utility.max_word_short_content + 1)..utility.max_word_medium_content
+    when (max_word_short + 1)..max_word_medium
       'medium'
     else
       'long'
@@ -34,6 +34,14 @@ class Note < ApplicationRecord
   end
 
   private
+
+  def max_word_short
+    (utility.max_word_short_content || 0)
+  end
+
+  def max_word_medium
+    (utility.max_word_medium_content || 2)
+  end
 
   def validate_review_word_count
     return unless word_count > utility.max_word_valid_review

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -23,11 +23,11 @@ class Note < ApplicationRecord
   end
 
   def short_limit
-    [utility.max_word_short_content.to_i, 1].max
+    utility.max_word_short_content.presence&.to_i || 1
   end
 
   def medium_limit
-    [utility.max_word_medium_content.to_i, short_limit + 2].max
+    utility.max_word_medium_content.presence&.to_i || short_limit + 2
   end
 
   def content_length

--- a/app/models/south_utility.rb
+++ b/app/models/south_utility.rb
@@ -2,12 +2,4 @@ class SouthUtility < Utility
   def max_word_valid_review
     60
   end
-
-  def max_word_short_content
-    60
-  end
-
-  def max_word_medium_content
-    120
-  end
 end

--- a/app/models/utility.rb
+++ b/app/models/utility.rb
@@ -28,7 +28,7 @@ class Utility < ApplicationRecord
   validates :name, :type, presence: true
 
   store_accessor :integration_urls, :external_api_authentication_url, :books_data_url,
-                 :notes_data_url
+                 :notes_data_url, :max_word_short_content, :max_word_medium_content
 
   def generate_entity_code
     return if code.present? && !code.to_i.zero?

--- a/app/views/admin/north_utilities/_show.html.arb
+++ b/app/views/admin/north_utilities/_show.html.arb
@@ -25,5 +25,11 @@ panel 'Utility' do
     row :notes_data_url do
       utility.notes_data_url
     end
+    row :max_words_for_short_content do
+      utility.max_word_short_content
+    end
+    row :max_words_for_medium_content do
+      utility.max_word_medium_content
+    end
   end
 end

--- a/app/views/admin/south_utilities/_show.html.arb
+++ b/app/views/admin/south_utilities/_show.html.arb
@@ -25,5 +25,11 @@ panel 'Utility' do
     row :notes_data_url do
       utility.notes_data_url
     end
+    row :max_words_for_short_content do
+      utility.max_word_short_content
+    end
+    row :max_words_for_medium_content do
+      utility.max_word_medium_content
+    end
   end
 end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Note, type: :model do
   end
 
   describe 'content_length' do
-    let(:south_utility) { create(:south_utility) }
-    let(:north_utility) { create(:north_utility) }
+    let(:south_utility) { create(:south_utility, max_word_short_content: 60, max_word_medium_content: 120) }
+    let(:north_utility) { create(:north_utility, max_word_short_content: 50, max_word_medium_content: 100) }
     let(:user_south) { create(:user, utility: south_utility) }
     let(:user_north) { create(:user, utility: north_utility) }
 
@@ -74,8 +74,8 @@ RSpec.describe Note, type: :model do
   end
 
   describe 'validate_review_word_count' do
-    let(:south_utility) { create(:south_utility) }
-    let(:north_utility) { create(:north_utility) }
+    let(:south_utility) { create(:south_utility, max_word_short_content: 60, max_word_medium_content: 120) }
+    let(:north_utility) { create(:north_utility, max_word_short_content: 50, max_word_medium_content: 100) }
     let(:user_south) { create(:user, utility: south_utility) }
     let(:user_north) { create(:user, utility: north_utility) }
 


### PR DESCRIPTION
## JIRA Card

https://widergy.atlassian.net/browse/TR-812

## Summary

Se modificó el modelo de Utility para que el máximo de palabras requerido para categorizar el tamaño de las notas no sea predefinido por la clase sino que se pueda actualizar por medio de Active Admin.

Se agregaron las vistas y acciones necesarias para poder interactuar con la interfaz y realizar dicho cambio.

También se hicieron cambios en el método `content_length` de `note.rb` con el fin de solventar los casos de tamaños no seteados 

Se actualizó la generación de utilities en los tests de Notes para que sean consistentes con estos cambios.

No se modificó documentación técnica

## Screenshots

En este caso tomaremos nota de id 35 perteneciente  al usuario logueado
<img width="1037" alt="Captura de pantalla 2025-04-15 a la(s) 5 45 09 p  m" src="https://github.com/user-attachments/assets/e14fc3fa-2435-402e-89db-b247c923edb3" />
<img width="1031" alt="Captura de pantalla 2025-04-15 a la(s) 5 45 43 p  m" src="https://github.com/user-attachments/assets/4936fc29-8966-4794-ba91-4ca3b4fd550d" />
<img width="1012" alt="Captura de pantalla 2025-04-15 a la(s) 5 47 47 p  m" src="https://github.com/user-attachments/assets/d54bbcbd-2d74-4fdf-9d6b-6ebed92150d5" />

Podemos ver que se asocia a la utility de id 2 
<img width="1017" alt="Captura de pantalla 2025-04-15 a la(s) 5 51 19 p  m" src="https://github.com/user-attachments/assets/c7b490f5-3c5d-4b56-969d-0b9a420e20c6" />

Podemos usar la interfaz y la consola para ver cómo está configurada, notaremos que no tiene ningún valor asignado para los máximos de palabras.
<img width="1383" alt="Captura de pantalla 2025-04-15 a la(s) 5 53 02 p  m" src="https://github.com/user-attachments/assets/d1918f9e-21c2-42f9-9784-1a0f86904889" />
<img width="1416" alt="Captura de pantalla 2025-04-15 a la(s) 5 54 30 p  m" src="https://github.com/user-attachments/assets/4a469406-606f-44a7-8eae-a9ee3fb85269" />
<img width="956" alt="Captura de pantalla 2025-04-15 a la(s) 5 58 53 p  m" src="https://github.com/user-attachments/assets/6f0d0cdc-f8be-4631-964e-60d7e5e387f3" />

En estos casos, el método content length toma valores por defecto para calcular la longitud, por lo que si el contenido no tiene ninguna palabra o solo una se considera corto, si tiene 2 o 3 mediano y si tiene 4 o más es largo. 
<img width="1029" alt="Captura de pantalla 2025-04-15 a la(s) 6 03 59 p  m" src="https://github.com/user-attachments/assets/262ad016-0d6d-4b19-be09-8862a20833ba" />
<img width="1023" alt="Captura de pantalla 2025-04-15 a la(s) 6 06 31 p  m" src="https://github.com/user-attachments/assets/fb663d56-b95c-4b09-be5e-b28c9d2df5b9" />

Si modificamos los límites por active admin entonces se tendrán en cuenta al momento de calcular el tamaño de la nota de nuevo.
<img width="1443" alt="Captura de pantalla 2025-04-15 a la(s) 6 10 13 p  m" src="https://github.com/user-attachments/assets/04db1f26-745e-42a0-8058-d9b3c7558751" />
<img width="1422" alt="Captura de pantalla 2025-04-15 a la(s) 6 12 46 p  m" src="https://github.com/user-attachments/assets/edd143ed-22cc-46f1-9539-53aa4617628a" />

<img width="1015" alt="Captura de pantalla 2025-04-16 a la(s) 8 55 48 a  m" src="https://github.com/user-attachments/assets/b806fdd4-6f05-46c3-8252-cf07d449b3b2" />
<img width="1018" alt="Captura de pantalla 2025-04-16 a la(s) 8 56 08 a  m" src="https://github.com/user-attachments/assets/04b4c01c-a0a3-4840-99e9-f4097b350967" />

Tests
<img width="921" alt="Captura de pantalla 2025-04-16 a la(s) 9 03 07 a  m" src="https://github.com/user-attachments/assets/6d28d53a-1a83-4ee8-984b-1f3af2daf18c" />

## Test Cases

N/A
